### PR TITLE
Re2-updated default image tag for K2HR3 APP and API

### DIFF
--- a/.github/workflows/helm_template.result
+++ b/.github/workflows/helm_template.result
@@ -2376,7 +2376,7 @@ spec:
               readOnly: true
       containers:
         - name: container-r3app-dummy
-          image: antpickax/k2hr3-app:1.0.18
+          image: antpickax/k2hr3-app:1.0.19
           env:
             - name: HTTP_PROXY
               value: ""
@@ -2673,7 +2673,7 @@ spec:
               readOnly: true
       containers:
         - name: container-r3api-dummy
-          image: antpickax/k2hr3-api:1.0.22
+          image: antpickax/k2hr3-api:1.0.23
           env:
             - name: HTTP_PROXY
               value: ""

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -271,7 +271,7 @@ Key: {{ b64enc $ca.Key }}
 	{{- else }}
 		{{- $tmpapporg  := "antpickax" }}
 		{{- $tmpappname := "k2hr3-app" }}
-		{{- $tmpappver  := "1.0.18" }}
+		{{- $tmpappver  := "1.0.19" }}
 		{{- if .Values.images.app.organization }}
 			{{- $tmpapporg = .Values.images.app.organization }}
 		{{- end }}
@@ -291,7 +291,7 @@ Key: {{ b64enc $ca.Key }}
 	{{- else }}
 		{{- $tmpapiorg  := "antpickax" }}
 		{{- $tmpapiname := "k2hr3-api" }}
-		{{- $tmpapiver  := "1.0.22" }}
+		{{- $tmpapiver  := "1.0.23" }}
 		{{- if .Values.images.api.organization }}
 			{{- $tmpapiorg = .Values.images.api.organization }}
 		{{- end }}


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
With the version upgrade of `K2HR3 API` and `K2HR3 APP`, the default image tag has been re-updated to the latest one.