### PR TITLE
Changed Service Account creation can be dis/enable

### DIFF
--- a/questions.yaml
+++ b/questions.yaml
@@ -241,6 +241,14 @@ questions:
   required: false
   group: "K2HR3 REST API"
 
+- variable: serviceAccount.create
+  default: true
+  label: "Create Service Account"
+  description: "Specify whether to create Service Account for K2HR3 API."
+  type: boolean
+  required: false
+  group: "K2HR3 REST API"
+
 #
 # Backend K2HDKC Cluster
 #

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -258,7 +258,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 */}}
 {{- define "k2hr3.serviceAccountName" -}}
 	{{- if .Values.serviceAccount.create }}
-		{{- default (include "k2hr3.fullname" .) .Values.serviceAccount.name }}
+		{{- if .Values.serviceAccount.name }}
+			{{- .Values.serviceAccount.name }}
+		{{- else }}
+			{{- printf "sa-%s" (include "k2hr3.r3apiBaseName" .) }}
+		{{- end }}
 	{{- else }}
 		{{- default "default" .Values.serviceAccount.name }}
 	{{- end }}

--- a/templates/k2hr3-k2hr3api.yaml
+++ b/templates/k2hr3-k2hr3api.yaml
@@ -53,7 +53,7 @@ spec:
       labels:
         app: {{ include "k2hr3.r3apiBaseName" . }}
     spec:
-      serviceAccountName: sa-{{ include "k2hr3.r3apiBaseName" . }}
+      serviceAccountName: {{ include "k2hr3.serviceAccountName" . }}
       volumes:
         - name: antpickax-etc-volume
           emptyDir:

--- a/templates/k2hr3-sa.yaml
+++ b/templates/k2hr3-sa.yaml
@@ -19,12 +19,13 @@
 * REVISION:
 *
 */ -}}
+{{- if ne (include "k2hr3.serviceAccountName" .) "default" }}
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sa-{{ include "k2hr3.r3apiBaseName" . }}
+  name: {{ include "k2hr3.serviceAccountName" . }}
   namespace: {{ include "k2hr3.k8sNamespace" . }}
 automountServiceAccountToken: true
 
@@ -49,9 +50,10 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: sa-{{ include "k2hr3.r3apiBaseName" . }}
+  name: {{ include "k2hr3.serviceAccountName" . }}
   namespace: {{ include "k2hr3.k8sNamespace" . }}
 
+{{- end }}
 {{-
 /*
 * Local variables:

--- a/values.schema.json
+++ b/values.schema.json
@@ -15,11 +15,11 @@
     },
 
     "serviceAccount": {
-      "description": "[optional] Service account setting.",
+      "description": "[optional] Service account setting for K2HR3 API.",
       "type": "object",
       "properties": {
         "create": {
-          "description": "[optional] Specifies whether to create a service account, default is true.",
+          "description": "[optional] Specifies whether to create a service account, default is true. If set false, not create service account.",
           "type": "boolean"
         },
         "annotations": {


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Added the following options:
#### LOCAL TENANTS
Added an option to enable/disable `LOCAL TENANT`.
#### Service Account
Added an option whether or not to create a `Service Account`.